### PR TITLE
#define __debugbreak for msvc compiles

### DIFF
--- a/debugbreak.h
+++ b/debugbreak.h
@@ -27,6 +27,12 @@
 #ifndef DEBUG_BREAK_H
 #define DEBUG_BREAK_H
 
+#ifdef _MSC_VER
+
+#define debug_break __debugbreak
+
+#else
+
 #include <signal.h>
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -108,6 +114,8 @@ static void __inline__ debug_break(void)
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
As the title says, this #define's __debugbreak for MSVC builds.
