### PR TITLE
fixed error with -Werror=old-style-declaration

### DIFF
--- a/debugbreak.h
+++ b/debugbreak.h
@@ -48,7 +48,7 @@ enum {
 #if defined(__i386__) || defined(__x86_64__)
 enum { HAVE_TRAP_INSTRUCTION = 1, };
 __attribute__((gnu_inline, always_inline))
-static void __inline__ trap_instruction(void)
+__inline__ static void trap_instruction(void)
 {
 	__asm__ volatile("int $0x03");
 }
@@ -56,7 +56,7 @@ static void __inline__ trap_instruction(void)
 enum { HAVE_TRAP_INSTRUCTION = 1, };
 /* FIXME: handle __THUMB_INTERWORK__ */
 __attribute__((gnu_inline, always_inline))
-static void __inline__ trap_instruction(void)
+__inline__ static void trap_instruction(void)
 {
 	/* See 'arm-linux-tdep.c' in GDB source.
 	 * Both instruction sequences below work. */
@@ -83,7 +83,7 @@ static void __inline__ trap_instruction(void)
 #elif defined(__arm__) && !defined(__thumb__)
 enum { HAVE_TRAP_INSTRUCTION = 1, };
 __attribute__((gnu_inline, always_inline))
-static void __inline__ trap_instruction(void)
+__inline__ static void trap_instruction(void)
 {
 	/* See 'arm-linux-tdep.c' in GDB source,
 	 * 'eabi_linux_arm_le_breakpoint' */
@@ -94,7 +94,7 @@ static void __inline__ trap_instruction(void)
 #elif defined(__aarch64__)
 enum { HAVE_TRAP_INSTRUCTION = 1, };
 __attribute__((gnu_inline, always_inline))
-static void __inline__ trap_instruction(void)
+__inline__ static void trap_instruction(void)
 {
 	/* See 'aarch64-tdep.c' in GDB source,
 	 * 'aarch64_default_breakpoint' */
@@ -105,7 +105,7 @@ enum { HAVE_TRAP_INSTRUCTION = 0, };
 #endif
 
 __attribute__((gnu_inline, always_inline))
-static void __inline__ debug_break(void)
+__inline__ static void debug_break(void)
 {
 	if (HAVE_TRAP_INSTRUCTION) {
 		trap_instruction();


### PR DESCRIPTION
With GCC 6.1.1:
debugbreak/debugbreak.h:51:1: error: '__inline__' is not at beginning of
declaration [-Werror=old-style-declaration]

So i moved the inlines at the beginning of the declaration.