### PR TITLE
arm64 iOS uses __builtin_trap()[@lydonchandra], why not merge?

### DIFF
--- a/debugbreak.h
+++ b/debugbreak.h
@@ -91,6 +91,13 @@ __inline__ static void trap_instruction(void)
 	/* Has same known problem and workaround
 	 * as Thumb mode */
 }
+#elif defined(__aarch64__) && defined(__APPLE__)
+enum { HAVE_TRAP_INSTRUCTION = 1, };
+__attribute__((gnu_inline, always_inline))
+static void __inline__ trap_instruction(void)
+{
+	__builtin_trap();
+}
 #elif defined(__aarch64__)
 enum { HAVE_TRAP_INSTRUCTION = 1, };
 __attribute__((gnu_inline, always_inline))


### PR DESCRIPTION
the origin code will raise such error. thanks for @lydonchandra PR.

```
In file included from src/macho.cpp:29:
src/debugbreak.h:101:19: error: unknown directive
        __asm__ volatile(".inst 0xd4200000");
                         ^
<inline asm>:1:2: note: instantiated into assembly here
        .inst 0xd4200000
        ^
1 error generated.
```

but i don't know why not merge? 😂