### PR TITLE
Fix build issue on macOS (aarch64, gcc) and use debugtrap wherever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ See table below for the behavior of **debug_break()** on other architecturs.
 Behavior on Different Architectures
 ----------------
 
+`__builtin_debugtrap()` is used wherever available, otherwise:
+
 | Architecture       | debug_break() |
 | -------------      | ------------- |
 | x86/x86-64         | `int3`  |
@@ -122,6 +124,4 @@ Behavior on Different Architectures
 | POWER              | `.4byte 0x7d821008` |
 | RISC-V             | `.4byte 0x00100073` |
 | MSVC compiler      | `__debugbreak` |
-| Apple compiler on AArch64     | `__builtin_trap()` |
 | Otherwise          | `raise(SIGTRAP)` |
-

--- a/debugbreak.h
+++ b/debugbreak.h
@@ -91,8 +91,6 @@ __inline__ static void trap_instruction(void)
 	/* Known problem:
 	 * Same problem and workaround as Thumb mode */
 }
-#elif defined(__aarch64__) && defined(__APPLE__)
-	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BUILTIN_DEBUGTRAP
 #elif defined(__aarch64__)
 	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
 __attribute__((always_inline))
@@ -134,6 +132,12 @@ __inline__ static void trap_instruction(void)
 	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_SIGTRAP
 #endif
 
+#if defined(__has_builtin)
+# if __has_builtin(__builtin_debugtrap)
+#  undef DEBUG_BREAK_IMPL
+#  define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BUILTIN_DEBUGTRAP
+# endif
+#endif
 
 #ifndef DEBUG_BREAK_IMPL
 #error "debugbreak.h is not supported on this target"

--- a/debugbreak.h
+++ b/debugbreak.h
@@ -37,8 +37,9 @@ extern "C" {
 #endif
 
 #define DEBUG_BREAK_USE_TRAP_INSTRUCTION 1
-#define DEBUG_BREAK_USE_BULTIN_TRAP      2
+#define DEBUG_BREAK_USE_BUILTIN_TRAP     2
 #define DEBUG_BREAK_USE_SIGTRAP          3
+#define DEBUG_BREAK_USE_BUILTIN_DEBUGTRAP 4
 
 #if defined(__i386__) || defined(__x86_64__)
 	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
@@ -91,7 +92,7 @@ __inline__ static void trap_instruction(void)
 	 * Same problem and workaround as Thumb mode */
 }
 #elif defined(__aarch64__) && defined(__APPLE__)
-	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BULTIN_DEBUGTRAP
+	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BUILTIN_DEBUGTRAP
 #elif defined(__aarch64__)
 	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
 __attribute__((always_inline))
@@ -142,13 +143,13 @@ __inline__ static void debug_break(void)
 {
 	trap_instruction();
 }
-#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_BULTIN_DEBUGTRAP
+#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_BUILTIN_DEBUGTRAP
 __attribute__((always_inline))
 __inline__ static void debug_break(void)
 {
 	__builtin_debugtrap();
 }
-#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_BULTIN_TRAP
+#elif DEBUG_BREAK_IMPL == DEBUG_BREAK_USE_BUILTIN_TRAP
 __attribute__((always_inline))
 __inline__ static void debug_break(void)
 {


### PR DESCRIPTION
This PR makes `debugbreak` prefer `__builtin_debugtrap()` wherever it's available (clang).

The code snippet I've used is @jwakely's work, I've added a signoff to my commit message to mark the original author.

The patch fixes a build issue too on macOS (Apple silicon) when a real GCC compiler is used:
> warning: implicit declaration of function '__builtin_debugtrap';

Depends on #22
Fixes #24

----

I'm testing this change on the following architectures (with clang + gcc):
- [x] x86-64
  - gcc/clang: works
- [x] ARM mode, 32-bit (Raspberry Pi 1 armv6l)
  - gcc/clang: works (stepping in GDB does NOT work)
- [x] Thumb mode, 32-bit (Cirrus CI)
  - gcc/clang: works (stepping in GDB does NOT work)
- [x] AArch64, ARMv8 (Raspberry Pi 4)
  - gcc/clang: works (stepping in GDB does NOT work)
- [x] Apple silicon (macOS M1 machine):
  - gcc: works (stepping in LLDB does NOT work)
  - clang: works

Unfortunately, I won't be able to test the change on riscv and powerpc.